### PR TITLE
Feature/#13 회원가입 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
     //swagger UI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'com.opencsv:opencsv:5.5.2'
+
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/comento/auth/annotation/AuthenticationUser.java
+++ b/src/main/java/com/example/comento/auth/annotation/AuthenticationUser.java
@@ -1,0 +1,11 @@
+package com.example.comento.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationUser {
+}

--- a/src/main/java/com/example/comento/auth/annotation/resolver/AuthenticatedUserArgumentResolver.java
+++ b/src/main/java/com/example/comento/auth/annotation/resolver/AuthenticatedUserArgumentResolver.java
@@ -1,0 +1,27 @@
+package com.example.comento.auth.annotation.resolver;
+
+import com.example.comento.auth.annotation.AuthenticationUser;
+import com.example.comento.auth.util.authentication.AuthenticationContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final AuthenticationContext authenticationContext;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticationUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return authenticationContext.getPrincipal();
+    }
+}

--- a/src/main/java/com/example/comento/auth/config/AuthenticationConfig.java
+++ b/src/main/java/com/example/comento/auth/config/AuthenticationConfig.java
@@ -1,0 +1,36 @@
+package com.example.comento.auth.config;
+
+
+import com.example.comento.auth.annotation.resolver.AuthenticatedUserArgumentResolver;
+import com.example.comento.auth.intercepter.AuthenticationInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthenticationConfig implements WebMvcConfigurer {
+    private final AuthenticationInterceptor authenticationInterceptor;
+    private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
+
+    private static final String[] EXCLUDE_PATH_PATTERNS = {
+        "/auth/sign-up", "/auth/login", "/users/ranking", "/problems", "/problems/algorithms", "/problems/collections"
+    };
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(EXCLUDE_PATH_PATTERNS);
+
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/comento/auth/constant/RegularExpressionPatterns.java
+++ b/src/main/java/com/example/comento/auth/constant/RegularExpressionPatterns.java
@@ -1,0 +1,8 @@
+package com.example.comento.auth.constant;
+
+public class RegularExpressionPatterns {
+
+    public static final String APPLICATION_USERID_PATTERN = "^(?=.*[A-Za-z])(?=.*[\\d])[A-Za-z\\d]{6,15}$"; //영어, 숫자 포함 6~15자
+    public static final String APPLICATION_PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*_\\-+='|\\\\(){}\\[\\]:;'\"<>,.?/]).{8,15}$"; //영어,숫자, 특수문자 포함 8~15자
+    public static final String APPLICATION_USERNAME_PATTERN = "^[a-zA-Z가-힣]{2,8}$"; //영어나 한글로 2~8자
+}

--- a/src/main/java/com/example/comento/auth/constant/TokenConstant.java
+++ b/src/main/java/com/example/comento/auth/constant/TokenConstant.java
@@ -1,0 +1,6 @@
+package com.example.comento.auth.constant;
+
+public class TokenConstant {
+
+    public static final String ACCESS_TOKEN = "AccessToken";
+}

--- a/src/main/java/com/example/comento/auth/controller/AuthController.java
+++ b/src/main/java/com/example/comento/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.example.comento.auth.controller;
+
+import com.example.comento.auth.dto.request.SignUpRequest;
+import com.example.comento.auth.service.AuthService;
+import com.example.comento.global.dto.ResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<ResponseDto<Void>> signUp(@Valid @RequestBody SignUpRequest request){
+        authService.signUp(request);
+        return new ResponseEntity<>(ResponseDto.res(true, "회원가입 성공 "), HttpStatus.CREATED);
+    }
+
+
+}

--- a/src/main/java/com/example/comento/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/comento/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,30 @@
+package com.example.comento.auth.dto.request;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+import static com.example.comento.auth.constant.RegularExpressionPatterns.*;
+
+@Getter
+public class SignUpRequest {
+
+    @NotBlank(message = "아이디를 입력해주세요.")
+    @Pattern(regexp = APPLICATION_USERID_PATTERN, message = "아이디는 영문과 숫자를 포함해야 하며, 6자 이상, 15자 이하여야 합니다.")
+    private String id;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = APPLICATION_PASSWORD_PATTERN, message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 하며, 8자 이상, 15자 이하여야 합니다.")
+    private String password;
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Pattern(regexp = APPLICATION_USERNAME_PATTERN, message = "닉네임은 영어나 한글로 작성하며 2자 이상, 8자 이하여야 합니다.")
+    private String name;
+
+}

--- a/src/main/java/com/example/comento/auth/intercepter/AuthenticationInterceptor.java
+++ b/src/main/java/com/example/comento/auth/intercepter/AuthenticationInterceptor.java
@@ -34,6 +34,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
                              final HttpServletResponse response,
                              final Object handler) throws Exception {
 
+        UriMatcher problemDetailUriMatcher = new UriMatcher(HttpMethod.GET, "/problems/{problem-id}");
+
+        if(problemDetailUriMatcher.match(request)) return true;
+
         String accessToken = AuthenticationExtractor.extract(request);
         UUID id = UUID.fromString(accessTokenProvider.getPayload(accessToken));
         User user = findUserByUserId(id);

--- a/src/main/java/com/example/comento/auth/intercepter/AuthenticationInterceptor.java
+++ b/src/main/java/com/example/comento/auth/intercepter/AuthenticationInterceptor.java
@@ -1,0 +1,47 @@
+package com.example.comento.auth.intercepter;
+
+import com.example.comento.auth.util.authentication.AuthenticationContext;
+import com.example.comento.auth.util.authentication.AuthenticationExtractor;
+import com.example.comento.auth.util.jwt.AccessTokenProvider;
+import com.example.comento.auth.util.jwt.JwtProvider;
+import com.example.comento.global.exception.NotFoundException;
+import com.example.comento.global.exception.errorcode.ErrorCode;
+import com.example.comento.global.util.UriMatcher;
+import com.example.comento.user.domain.User;
+import com.example.comento.user.repository.UserJpaRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final AuthenticationContext authenticationContext;
+    private final UserJpaRepository userJpaRepository;
+    private final AccessTokenProvider accessTokenProvider;
+
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request,
+                             final HttpServletResponse response,
+                             final Object handler) throws Exception {
+
+        String accessToken = AuthenticationExtractor.extract(request);
+        UUID id = UUID.fromString(accessTokenProvider.getPayload(accessToken));
+        User user = findUserByUserId(id);
+        authenticationContext.setPrincipal(user);
+        return true;
+    }
+
+    private User findUserByUserId(UUID id){
+        return userJpaRepository.findById(id).orElseThrow(()-> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/comento/auth/service/AuthService.java
+++ b/src/main/java/com/example/comento/auth/service/AuthService.java
@@ -1,0 +1,45 @@
+package com.example.comento.auth.service;
+
+import com.example.comento.auth.dto.request.SignUpRequest;
+import com.example.comento.auth.util.password.PasswordHashEncryption;
+import com.example.comento.user.domain.User;
+import com.example.comento.user.domain.UserProfile;
+import com.example.comento.user.repository.UserJpaRepository;
+import com.example.comento.user.repository.UserProfileJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+
+    private final PasswordHashEncryption passwordHashEncryption;
+    private final UserJpaRepository userJpaRepository;
+    private final UserProfileJpaRepository userProfileJpaRepository;
+
+
+    @Transactional
+    public void signUp(SignUpRequest request){
+        String salt = issueSalt();
+        String hashedPassword = passwordHashEncryption.encrypt(request.getPassword(), salt);
+        User user = new User(request.getId(), hashedPassword, salt, request.getEmail(), request.getName());
+        userJpaRepository.save(user);
+    }
+
+    /**
+     *
+     * @return SecureRandom으로 salt값을 생성해 반환
+     */
+    private String  issueSalt(){
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] salt = new byte[16];
+        secureRandom.nextBytes(salt);
+        return Base64.getEncoder().encodeToString(salt); //Base64 인코딩 사용.
+    }
+}

--- a/src/main/java/com/example/comento/auth/util/authentication/AuthenticationContext.java
+++ b/src/main/java/com/example/comento/auth/util/authentication/AuthenticationContext.java
@@ -1,0 +1,16 @@
+package com.example.comento.auth.util.authentication;
+
+import com.example.comento.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Setter
+@Getter
+@Component
+@RequestScope
+public class AuthenticationContext {
+    private User principal;
+}

--- a/src/main/java/com/example/comento/auth/util/authentication/AuthenticationExtractor.java
+++ b/src/main/java/com/example/comento/auth/util/authentication/AuthenticationExtractor.java
@@ -1,0 +1,19 @@
+package com.example.comento.auth.util.authentication;
+
+import com.example.comento.auth.util.jwt.JwtEncoder;
+import com.example.comento.auth.util.jwt.JwtProvider;
+import com.example.comento.global.exception.UnauthorizedException;
+import com.example.comento.global.exception.errorcode.ErrorCode;
+import com.example.comento.global.util.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+import static com.example.comento.auth.constant.TokenConstant.ACCESS_TOKEN;
+
+public class AuthenticationExtractor {
+    private AuthenticationExtractor(){}
+    public static String extract(final HttpServletRequest request){
+        Cookie cookie = CookieUtil.getCookie(request, ACCESS_TOKEN);
+        return JwtEncoder.decodeJwtBearerToken(cookie.getValue());
+    }
+}

--- a/src/main/java/com/example/comento/auth/util/jwt/AccessTokenProvider.java
+++ b/src/main/java/com/example/comento/auth/util/jwt/AccessTokenProvider.java
@@ -1,0 +1,12 @@
+package com.example.comento.auth.util.jwt;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccessTokenProvider extends JwtProvider {
+    public AccessTokenProvider(@Value("${security.jwt.access-token.secret-key}") String key,
+                               @Value("${security.jwt.access-token.expire-length}") long validityInMilliseconds) {
+        super(key, validityInMilliseconds);
+    }
+}

--- a/src/main/java/com/example/comento/auth/util/jwt/JwtEncoder.java
+++ b/src/main/java/com/example/comento/auth/util/jwt/JwtEncoder.java
@@ -17,7 +17,7 @@ public class JwtEncoder {
         return URLEncoder.encode(cookieValue, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
     }
 
-    public static String decodeJwtBearerToken(String value){
-        return URLDecoder.decode(value, StandardCharsets.UTF_8).substring(7);
+    public static String decodeJwtBearerToken(String cookieValue){
+        return URLDecoder.decode(cookieValue, StandardCharsets.UTF_8).substring(7);
     }
 }

--- a/src/main/java/com/example/comento/auth/util/jwt/JwtEncoder.java
+++ b/src/main/java/com/example/comento/auth/util/jwt/JwtEncoder.java
@@ -1,0 +1,23 @@
+package com.example.comento.auth.util.jwt;
+
+import org.springframework.stereotype.Component;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class JwtEncoder {
+    public static final String TOKEN_TYPE = "Bearer ";
+
+    private JwtEncoder(){}
+
+    public static String encodeJwtToken(String token){
+        String cookieValue = TOKEN_TYPE+token;
+        return URLEncoder.encode(cookieValue, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+    }
+
+    public static String decodeJwtBearerToken(String value){
+        return URLDecoder.decode(value, StandardCharsets.UTF_8).substring(7);
+    }
+}

--- a/src/main/java/com/example/comento/auth/util/jwt/JwtProvider.java
+++ b/src/main/java/com/example/comento/auth/util/jwt/JwtProvider.java
@@ -1,0 +1,50 @@
+package com.example.comento.auth.util.jwt;
+
+import com.example.comento.global.exception.UnauthorizedException;
+import com.example.comento.global.exception.errorcode.ErrorCode;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+
+public class JwtProvider {
+
+    private final SecretKey key;
+    private final long validityInMilliseconds;
+
+    //상속 받는 토큰 provider만 생성자를 사용하도록 함.
+    protected JwtProvider(String key, long validityInMilliseconds){
+        this.key = Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8));
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
+
+    public String createToken(final String payload){
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + validityInMilliseconds);
+        return Jwts.builder()
+                .setExpiration(expiration)
+                .setSubject(payload)
+                .setIssuedAt(now)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getPayload(final String token){
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        }catch (JwtException e){
+            throw new UnauthorizedException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+}

--- a/src/main/java/com/example/comento/auth/util/password/PasswordHashEncryption.java
+++ b/src/main/java/com/example/comento/auth/util/password/PasswordHashEncryption.java
@@ -1,0 +1,46 @@
+package com.example.comento.auth.util.password;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+
+@Component
+public class PasswordHashEncryption {
+
+    private static final String PBKDF2_WITH_SHA1 = "PBKDF2WithHmacSHA1";
+
+    private final int iterationCount;// 반복 횟수(암호화 강도)
+    private final int keyLength;// 키 길이(암호화된 비밀번호 길이)
+
+
+    public PasswordHashEncryption(@Value("${encryption.pbkdf2.iteration-count}") final int iteration,
+                                  @Value("${encryption.pbkdf2.key-length}") final int keyLength){
+        this.iterationCount = iteration;
+        this.keyLength = keyLength;
+    }
+
+    public String encrypt(final String plainPassword, final String salt){
+        try{
+            KeySpec spec = new PBEKeySpec(plainPassword.toCharArray(), salt.getBytes(), iterationCount, keyLength);
+            SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(PBKDF2_WITH_SHA1);
+            byte[] encodedPassword = keyFactory.generateSecret(spec)
+                    .getEncoded();
+            return Base64.getEncoder()
+                    .withoutPadding()
+                    .encodeToString(encodedPassword);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException("Cannot encrypt password");
+        }
+    }
+
+    public boolean matches(final String plainPassword, final String salt, final String hashedPassword){
+        return encrypt(plainPassword, salt).equals(hashedPassword);
+    }
+
+}

--- a/src/main/java/com/example/comento/collection/repository/CollectionJpaRepository.java
+++ b/src/main/java/com/example/comento/collection/repository/CollectionJpaRepository.java
@@ -1,11 +1,11 @@
 package com.example.comento.collection.repository;
 
-import org.hibernate.sql.ast.tree.expression.Collation;
+import com.example.comento.collection.domain.Collection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-public interface CollectionJpaRepository extends JpaRepository<Collation, UUID> {
+public interface CollectionJpaRepository extends JpaRepository<Collection, UUID> {
 }

--- a/src/main/java/com/example/comento/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/example/comento/global/exception/errorcode/ErrorCode.java
@@ -15,6 +15,15 @@ public enum ErrorCode {
     LENGTH("4003", "길이가 유효하지 않습니다."),
     EMAIL("4004", "이메일 형식이 유효하지 않습니다."),
     NOT_NULL("4005", "필수값이 공백입니다."),
+
+    //Unauthorized
+    INVALID_TOKEN("4011", "유효하지 않은 토큰입니다."),
+    TOKEN_NOT_FOUND("4012", "토큰이 존재하지 않습니다."),
+
+    //Not_Found
+    USER_NOT_FOUND("4040", "존재하지 않는 유저입니다"),
+
+
     ;
 
 

--- a/src/main/java/com/example/comento/global/util/CookieUtil.java
+++ b/src/main/java/com/example/comento/global/util/CookieUtil.java
@@ -1,0 +1,36 @@
+package com.example.comento.global.util;
+
+import com.example.comento.global.exception.UnauthorizedException;
+import com.example.comento.global.exception.errorcode.ErrorCode;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+
+public class CookieUtil {
+    private CookieUtil(){}
+    public static ResponseCookie createTokenCookie(
+            String tokenName, String tokenValue, Duration maxAge, String path){
+        return ResponseCookie.from(tokenName, tokenValue)
+                .maxAge(maxAge)
+                .path(path)
+                .httpOnly(true)
+                .sameSite("None")
+                .secure(true)
+                .build();
+    }
+
+    public static Cookie getCookie(final HttpServletRequest request, final String cookieName) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(cookieName)) {
+                    return cookie;
+                }
+            }
+        }
+        throw new UnauthorizedException(ErrorCode.TOKEN_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/comento/global/util/UriMatcher.java
+++ b/src/main/java/com/example/comento/global/util/UriMatcher.java
@@ -1,0 +1,26 @@
+package com.example.comento.global.util;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.util.UriTemplate;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class UriMatcher {
+    private final HttpMethod httpMethod;
+    private final String path;
+
+    public boolean matchWithExclusion(HttpServletRequest request, Collection<String> excludePatterns){
+        if(excludePatterns.stream().anyMatch(i -> i.equals(request.getRequestURI()))) return false;
+        UriTemplate uriTemplate = new UriTemplate(path);
+        return httpMethod.matches(request.getMethod()) && uriTemplate.matches(request.getRequestURI());
+    }
+
+    public boolean match(HttpServletRequest request){
+        UriTemplate uriTemplate = new UriTemplate(path);
+        return httpMethod.matches(request.getMethod()) && uriTemplate.matches(request.getRequestURI());
+    }
+}

--- a/src/main/java/com/example/comento/user/domain/User.java
+++ b/src/main/java/com/example/comento/user/domain/User.java
@@ -11,10 +11,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
-    @Column(unique = true, updatable = false)
+    @Column(unique = true)
     private String email;
     @Column(nullable = false)
     private String password;
+    @Column(nullable = false, updatable = false)
+    private String salt;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private UserProfile userProfile;

--- a/src/main/java/com/example/comento/user/domain/User.java
+++ b/src/main/java/com/example/comento/user/domain/User.java
@@ -11,14 +11,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
-    @Column(unique = true)
-    private String email;
+    @Column(nullable = false, unique = true)
+    private String userId;
+
     @Column(nullable = false)
     private String password;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
     @Column(nullable = false, updatable = false)
     private String salt;
 
+    @PrimaryKeyJoinColumn
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private UserProfile userProfile;
+
+    public User (String userId, String password, String salt, String email, String name){
+        this.userId = userId;
+        this.password = password;
+        this.email = email;
+        this.salt = salt;
+        this.userProfile = new UserProfile(this, name);
+    }
 
 }

--- a/src/main/java/com/example/comento/user/domain/UserProfile.java
+++ b/src/main/java/com/example/comento/user/domain/UserProfile.java
@@ -1,30 +1,35 @@
 package com.example.comento.user.domain;
 
+import com.example.comento.global.domain.BaseEntity;
 import com.example.comento.like.domain.ProblemLike;
 import com.example.comento.solution.domain.Solution;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Entity(name = "user_profile")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 public class UserProfile {
 
     @Id
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
+    @Column(name = "user_id", updatable = false, unique = true, nullable = false)
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId //User의 Pk를 UserProfile의 PK이자 Fk로 사용
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(nullable = false)
     private String name;
+
     @Column(nullable = false)
     private long experience;
 


### PR DESCRIPTION
## Description
회원가입 구현 

## Changes

### auth
- AuthController
- AuthService
- JwtEncoder
- JwtProvider
- AccessTokenProvider
- AuthenticationInterCeptor
- PasswordHashEncryption
- AuthenticationExctractor
- AuthenticationContext
- AuthenticatiedUser
- AuthenticatiedUserArgumentResolver
- SignUpRequest

### global
- UriMatcher
- CookieUtil

## Additional context
- 유저 테이블에 salt를 추가함
- AccessToken의 경우 추후 RefreshToken을 고려해서 JwtProvider를 상속 받는 형태로 구현함. 

Closes #13 