### PR TITLE
Refactor/#17 유저 id와 유저 프로필 id 분리

### DIFF
--- a/src/main/java/com/example/comento/user/domain/UserProfile.java
+++ b/src/main/java/com/example/comento/user/domain/UserProfile.java
@@ -15,17 +15,7 @@ import java.util.UUID;
 @Entity(name = "user_profile")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class UserProfile {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
-    @Column(name = "user_id", updatable = false, unique = true, nullable = false)
-    private UUID id;
-
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @MapsId //User의 Pk를 UserProfile의 PK이자 Fk로 사용
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+public class UserProfile extends BaseEntity{
 
     @Column(nullable = false)
     private String name;
@@ -33,14 +23,16 @@ public class UserProfile {
     @Column(nullable = false)
     private long experience;
 
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
-
-    public UserProfile (final User user, final String name){
+    //같은 패키지 내 user에서만 생성 가능.
+    protected UserProfile (final User user, final String name){
         this.user = user;
         this.name = name;
         this.experience = 0;
     }
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @OneToMany(mappedBy = "userProfile", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Solution> solution;


### PR DESCRIPTION
## Description
유저 프로필 id를 유저의 id와 분리 

## Changes

### user
- UserProfile

## Additional context
- 기존에 유저 id, 유저 프로필 id를 동일한 값을 사용하여 인증 유저 정보를 다루기 편하도록 했었음.
- 그러나 유저 프로필 조회 시 id 값이 공개될 수 있어서 이를 따로 분리함. 

Closes #17