### PR TITLE
Feature#23 유저 프로필 상세 조회 구현

### DIFF
--- a/src/main/java/com/example/comento/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/comento/auth/dto/request/SignUpRequest.java
@@ -19,9 +19,9 @@ public class SignUpRequest {
     @Pattern(regexp = APPLICATION_PASSWORD_PATTERN, message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 하며, 8자 이상, 15자 이하여야 합니다.")
     private String password;
 
-    @NotBlank(message = "이메일을 입력해주세요.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String email;
+//    @NotBlank(message = "이메일을 입력해주세요.")
+//    @Email(message = "올바른 이메일 형식이 아닙니다.")
+//    private String email;
 
     @NotBlank(message = "닉네임을 입력해주세요.")
     @Pattern(regexp = APPLICATION_USERNAME_PATTERN, message = "닉네임은 영어나 한글로 작성하며 2자 이상, 8자 이하여야 합니다.")

--- a/src/main/java/com/example/comento/auth/service/AuthService.java
+++ b/src/main/java/com/example/comento/auth/service/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService {
     public void signUp(SignUpRequest request){
         String salt = issueSalt();
         String hashedPassword = passwordHashEncryption.encrypt(request.getPassword(), salt);
-        User user = new User(request.getUserId(), hashedPassword, salt, request.getEmail(), request.getName());
+        User user = new User(request.getUserId(), hashedPassword, salt, request.getName());
         userJpaRepository.save(user);
     }
 

--- a/src/main/java/com/example/comento/category/domain/Category.java
+++ b/src/main/java/com/example/comento/category/domain/Category.java
@@ -1,6 +1,6 @@
 package com.example.comento.category.domain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.problem.damain.ProblemCategory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -12,7 +12,7 @@ import java.util.List;
 @Entity(name = "category")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Category extends BaseEntity {
+public class Category extends UuidTypeBaseEntity {
 
     @Column(nullable = false, unique = true)
     private String name;

--- a/src/main/java/com/example/comento/collection/domain/Collection.java
+++ b/src/main/java/com/example/comento/collection/domain/Collection.java
@@ -1,6 +1,6 @@
 package com.example.comento.collection.domain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.problem.damain.ProblemCollection;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -13,7 +13,7 @@ import java.util.List;
 @Entity(name = "collection")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Collection extends BaseEntity {
+public class Collection extends UuidTypeBaseEntity {
 
     @Column(nullable = false, unique = true)
     private String name;

--- a/src/main/java/com/example/comento/global/domain/LongTypeBaseEntity.java
+++ b/src/main/java/com/example/comento/global/domain/LongTypeBaseEntity.java
@@ -13,12 +13,13 @@ import java.util.UUID;
 @MappedSuperclass
 @Getter
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
+public class LongTypeBaseEntity {
+
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false, unique = true, nullable = false)
-    private UUID id;
+    private Long id;
 
     @CreatedDate
     private LocalDateTime createdAt;
@@ -34,7 +35,7 @@ public abstract class BaseEntity {
         if(o==null || this.getClass() != o.getClass()){
             return false;
         }
-        return this.id.equals(((BaseEntity) o).id);
+        return this.id.equals(((LongTypeBaseEntity) o).id);
     }
 
     @Override

--- a/src/main/java/com/example/comento/global/domain/UuidTypeBaseEntity.java
+++ b/src/main/java/com/example/comento/global/domain/UuidTypeBaseEntity.java
@@ -1,0 +1,44 @@
+package com.example.comento.global.domain;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class UuidTypeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
+    @Column(updatable = false, unique = true, nullable = false)
+    private UUID id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Override
+    public boolean equals(Object o){
+        if(this == o){
+            return true;
+        }
+        if(o==null || this.getClass() != o.getClass()){
+            return false;
+        }
+        return this.id.equals(((UuidTypeBaseEntity) o).id);
+    }
+
+    @Override
+    public int hashCode(){
+        return this.id.hashCode();
+    }
+}

--- a/src/main/java/com/example/comento/level/domain/Level.java
+++ b/src/main/java/com/example/comento/level/domain/Level.java
@@ -1,6 +1,6 @@
 package com.example.comento.level.domain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.problem.damain.ProblemLevel;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -12,7 +12,7 @@ import java.util.List;
 @Entity(name = "level")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Level extends BaseEntity {
+public class Level extends UuidTypeBaseEntity {
 
     @Column(nullable = false)
     private long experience;

--- a/src/main/java/com/example/comento/like/domain/ProblemLike.java
+++ b/src/main/java/com/example/comento/like/domain/ProblemLike.java
@@ -1,6 +1,6 @@
 package com.example.comento.like.domain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.problem.damain.Problem;
 import com.example.comento.user.domain.UserProfile;
 import jakarta.persistence.Entity;
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "problem_like")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProblemLike extends BaseEntity {
+public class ProblemLike extends UuidTypeBaseEntity {
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
 //    @JoinColumn(name = "user_profile_id", nullable = false)

--- a/src/main/java/com/example/comento/problem/damain/Problem.java
+++ b/src/main/java/com/example/comento/problem/damain/Problem.java
@@ -1,6 +1,6 @@
 package com.example.comento.problem.damain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.LongTypeBaseEntity;
 import com.example.comento.like.domain.ProblemLike;
 import com.example.comento.solution.domain.Solution;
 import jakarta.persistence.*;
@@ -13,7 +13,7 @@ import java.util.List;
 @Entity(name = "problem")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Problem extends BaseEntity {
+public class Problem extends LongTypeBaseEntity {
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/com/example/comento/problem/damain/ProblemCategory.java
+++ b/src/main/java/com/example/comento/problem/damain/ProblemCategory.java
@@ -1,7 +1,7 @@
 package com.example.comento.problem.damain;
 
 import com.example.comento.category.domain.Category;
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "problem_category")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ProblemCategory extends BaseEntity {
+public class ProblemCategory extends UuidTypeBaseEntity {
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;

--- a/src/main/java/com/example/comento/problem/damain/ProblemCollection.java
+++ b/src/main/java/com/example/comento/problem/damain/ProblemCollection.java
@@ -1,7 +1,7 @@
 package com.example.comento.problem.damain;
 
 import com.example.comento.collection.domain.Collection;
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity(name = "problem_collection")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProblemCollection extends BaseEntity {
+public class ProblemCollection extends UuidTypeBaseEntity {
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_id", nullable = false)

--- a/src/main/java/com/example/comento/problem/damain/ProblemLevel.java
+++ b/src/main/java/com/example/comento/problem/damain/ProblemLevel.java
@@ -1,6 +1,6 @@
 package com.example.comento.problem.damain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.level.domain.Level;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "problem_level")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ProblemLevel extends BaseEntity {
+public class ProblemLevel extends UuidTypeBaseEntity {
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "level_id", nullable = false)

--- a/src/main/java/com/example/comento/problem/damain/TestCase.java
+++ b/src/main/java/com/example/comento/problem/damain/TestCase.java
@@ -1,7 +1,6 @@
 package com.example.comento.problem.damain;
 
-import com.example.comento.global.domain.BaseEntity;
-import com.example.comento.problem.damain.Problem;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "test_case")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TestCase extends BaseEntity {
+public class TestCase extends UuidTypeBaseEntity {
 
     @ManyToOne(optional = false, fetch = FetchType.EAGER)
     @JoinColumn(name = "problem_id", nullable = false)

--- a/src/main/java/com/example/comento/problem/repository/ProblemJpaRepository.java
+++ b/src/main/java/com/example/comento/problem/repository/ProblemJpaRepository.java
@@ -1,11 +1,41 @@
 package com.example.comento.problem.repository;
 
 import com.example.comento.problem.damain.Problem;
+import com.example.comento.solution.dao.ProblemId;
+import com.example.comento.user.domain.UserProfile;
+import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
-public interface ProblemJpaRepository extends JpaRepository<Problem, UUID> {
+public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
+
+    @Query("select p.id as id " +
+            "from problem as p " +
+            "left join solution as s on p.id = s.problem.id " +
+            "where s.isCorrect = true and s.userProfile = :profile " +
+            "group by p.id " +
+            "order by p.id desc")
+    List<ProblemId> getSolvedProblemList(@NonNull @Param("profile") UserProfile profile);
+
+    @Query("select p.id as id " +
+            "from problem as p " +
+            "where exists ( " +
+            "   select 1 " +
+            "   from solution as s " +
+            "   where s.userProfile = :profile and s.problem = p and s.isCorrect = false" +
+            ")" +
+            "and not exists (" +
+            "   select 1 " +
+            "   from solution s " +
+            "   where s.userProfile = :profile and s.problem = p and s.isCorrect = true " +
+            ")" +
+            "group by p.id " +
+            "order by p.id desc")
+    List<ProblemId> getFailedProblemList(UserProfile profile);
 }

--- a/src/main/java/com/example/comento/problem/service/ProblemService.java
+++ b/src/main/java/com/example/comento/problem/service/ProblemService.java
@@ -1,0 +1,12 @@
+package com.example.comento.problem.service;
+
+import com.example.comento.problem.repository.ProblemJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ProblemService {
+
+    private final ProblemJpaRepository problemJpaRepository;
+}

--- a/src/main/java/com/example/comento/solution/dao/ProblemId.java
+++ b/src/main/java/com/example/comento/solution/dao/ProblemId.java
@@ -1,0 +1,5 @@
+package com.example.comento.solution.dao;
+
+public interface ProblemId {
+    Long getId();
+}

--- a/src/main/java/com/example/comento/solution/domain/Solution.java
+++ b/src/main/java/com/example/comento/solution/domain/Solution.java
@@ -1,6 +1,6 @@
 package com.example.comento.solution.domain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.problem.damain.Problem;
 import com.example.comento.user.domain.UserProfile;
 import jakarta.persistence.*;
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "solution")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Solution extends BaseEntity {
+public class Solution extends UuidTypeBaseEntity {
 
     @Column(nullable = false)
     private String language;
@@ -24,7 +24,7 @@ public class Solution extends BaseEntity {
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
 //    @JoinColumn(name = "user_profile_id", nullable = false)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_profile_id", nullable = false)
     private UserProfile userProfile;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)

--- a/src/main/java/com/example/comento/solution/dto/response/ProblemIdsResponse.java
+++ b/src/main/java/com/example/comento/solution/dto/response/ProblemIdsResponse.java
@@ -1,0 +1,18 @@
+package com.example.comento.solution.dto.response;
+
+import com.example.comento.solution.dao.ProblemId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class ProblemIdsResponse {
+    private final List<Long> problemIds;
+
+    public static ProblemIdsResponse from(List<ProblemId> problemIds){
+        return new ProblemIdsResponse(problemIds.stream().map(ProblemId::getId).collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/example/comento/solution/service/SolutionService.java
+++ b/src/main/java/com/example/comento/solution/service/SolutionService.java
@@ -1,0 +1,29 @@
+package com.example.comento.solution.service;
+
+import com.example.comento.problem.repository.ProblemJpaRepository;
+import com.example.comento.solution.dao.ProblemId;
+import com.example.comento.solution.dto.response.ProblemIdsResponse;
+import com.example.comento.user.domain.UserProfile;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SolutionService {
+    private final ProblemJpaRepository problemJpaRepository;
+
+    public ProblemIdsResponse userSolvedList(UserProfile userProfile){
+        List<ProblemId> problemIdList = problemJpaRepository.getSolvedProblemList(userProfile);
+        problemIdList.forEach(i->log.info(i.getId().toString()));
+        return ProblemIdsResponse.from(problemIdList);
+    }
+
+    public ProblemIdsResponse userFailedList(UserProfile userProfile){
+        List<ProblemId> problemIdList = problemJpaRepository.getFailedProblemList(userProfile);
+        return ProblemIdsResponse.from(problemIdList);
+    }
+}

--- a/src/main/java/com/example/comento/user/controller/UserController.java
+++ b/src/main/java/com/example/comento/user/controller/UserController.java
@@ -1,7 +1,10 @@
 package com.example.comento.user.controller;
 
 import com.example.comento.global.dto.ResponseDto;
+import com.example.comento.user.domain.UserProfile;
+import com.example.comento.user.dto.response.DetailUserProfileResponse;
 import com.example.comento.user.dto.response.UserRankingResponse;
+import com.example.comento.user.service.UserProfileService;
 import com.example.comento.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -9,11 +12,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
     private final UserService userService;
+    private final UserProfileService userProfileService;
 
     @GetMapping("/ranking")
     @Operation(summary = "유저 랭킹 조회 api", description = "유저 경험치가 높은 순서 대로 정령, 경험치가 같은 경우 이름 순으로 정렬")
@@ -23,6 +29,12 @@ public class UserController {
         return new ResponseEntity<>(ResponseDto.res(true, "유저 랭킹 조회 성공", userRankingResponse), HttpStatus.OK);
     }
 
-
+    @GetMapping("/{userprofile-id}")
+    @Operation(summary = "유저 프로필 조회 api")
+    public ResponseEntity<ResponseDto<DetailUserProfileResponse>> getDetailProfile(
+            @PathVariable("userprofile-id")UUID userProfileId){
+        DetailUserProfileResponse detailProfile = userProfileService.getDetailProfile(userProfileId);
+        return new ResponseEntity<>(ResponseDto.res(true, "유저 랭킹 조회 성공", detailProfile), HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/com/example/comento/user/controller/UserController.java
+++ b/src/main/java/com/example/comento/user/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
     public ResponseEntity<ResponseDto<DetailUserProfileResponse>> getDetailProfile(
             @PathVariable("userprofile-id")UUID userProfileId){
         DetailUserProfileResponse detailProfile = userProfileService.getDetailProfile(userProfileId);
-        return new ResponseEntity<>(ResponseDto.res(true, "유저 랭킹 조회 성공", detailProfile), HttpStatus.OK);
+        return new ResponseEntity<>(ResponseDto.res(true, "유저 프로필 상세 조회 성공", detailProfile), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/comento/user/domain/User.java
+++ b/src/main/java/com/example/comento/user/domain/User.java
@@ -1,6 +1,6 @@
 package com.example.comento.user.domain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseEntity {
+public class User extends UuidTypeBaseEntity {
 
     @Column(nullable = false, unique = true)
     private String userId;

--- a/src/main/java/com/example/comento/user/domain/User.java
+++ b/src/main/java/com/example/comento/user/domain/User.java
@@ -17,8 +17,8 @@ public class User extends UuidTypeBaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+//    @Column(nullable = false, unique = true)
+//    private String email;
 
     @Column(nullable = false, updatable = false)
     private String salt;
@@ -27,10 +27,9 @@ public class User extends UuidTypeBaseEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private UserProfile userProfile;
 
-    public User (String userId, String password, String salt, String email, String name){
+    public User (String userId, String password, String salt, String name){
         this.userId = userId;
         this.password = password;
-        this.email = email;
         this.salt = salt;
         this.userProfile = new UserProfile(this, name);
     }

--- a/src/main/java/com/example/comento/user/domain/UserProfile.java
+++ b/src/main/java/com/example/comento/user/domain/UserProfile.java
@@ -1,21 +1,17 @@
 package com.example.comento.user.domain;
 
-import com.example.comento.global.domain.BaseEntity;
+import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.like.domain.ProblemLike;
 import com.example.comento.solution.domain.Solution;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 @Entity(name = "user_profile")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class UserProfile extends BaseEntity{
+public class UserProfile extends UuidTypeBaseEntity {
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/com/example/comento/user/dto/response/DetailUserProfileResponse.java
+++ b/src/main/java/com/example/comento/user/dto/response/DetailUserProfileResponse.java
@@ -1,0 +1,29 @@
+package com.example.comento.user.dto.response;
+
+import com.example.comento.solution.dto.response.ProblemIdsResponse;
+import com.example.comento.user.domain.UserProfile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class DetailUserProfileResponse {
+    private final String name;
+    private final Long experience;
+    private final List<Long> solvedProblemIds;
+    private final List<Long> failedProblemIds;
+
+    public static DetailUserProfileResponse from(
+            UserProfile profile,
+            ProblemIdsResponse solvedProblemIds,
+            ProblemIdsResponse failedProblemIds){
+
+        return new DetailUserProfileResponse(
+                profile.getName(),
+                profile.getExperience(),
+                solvedProblemIds.getProblemIds(),
+                failedProblemIds.getProblemIds());
+    }
+}

--- a/src/main/java/com/example/comento/user/repository/UserProfileJpaRepository.java
+++ b/src/main/java/com/example/comento/user/repository/UserProfileJpaRepository.java
@@ -1,6 +1,7 @@
 package com.example.comento.user.repository;
 
 import com.example.comento.user.dao.UserRankProfile;
+import com.example.comento.user.domain.User;
 import com.example.comento.user.domain.UserProfile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,17 +9,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface UserProfileJpaRepository extends JpaRepository<UserProfile, UUID> {
 
-
+    Optional<UserProfile> findByUser(User user);
 
     @Query("select up.name as name, up.experience as experience, count(s) as solvedCount " +
             "from user_profile as up " +
             "left join solution as s on up.id = s.userProfile.id and s.isCorrect = true " +
             "group by up.id " +
             "order by up.experience DESC, up.name ")
-    public Page<UserRankProfile> getUserRanking(Pageable pageable);
+    Page<UserRankProfile> getUserRanking(Pageable pageable);
 }

--- a/src/main/java/com/example/comento/user/service/UserProfileService.java
+++ b/src/main/java/com/example/comento/user/service/UserProfileService.java
@@ -1,0 +1,41 @@
+package com.example.comento.user.service;
+
+import com.example.comento.global.exception.NotFoundException;
+import com.example.comento.global.exception.errorcode.ErrorCode;
+import com.example.comento.solution.dao.ProblemId;
+import com.example.comento.solution.dto.response.ProblemIdsResponse;
+import com.example.comento.solution.service.SolutionService;
+import com.example.comento.user.domain.User;
+import com.example.comento.user.domain.UserProfile;
+import com.example.comento.user.dto.response.DetailUserProfileResponse;
+import com.example.comento.user.repository.UserProfileJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserProfileService {
+
+    private final SolutionService solutionService;
+    private final UserProfileJpaRepository userProfileJpaRepository;
+
+    public DetailUserProfileResponse getDetailProfile(UUID userProfileId){
+        UserProfile userProfile = findById(userProfileId);
+        ProblemIdsResponse solvedProblemIds = solutionService.userSolvedList(userProfile);
+        ProblemIdsResponse failedProblemIds = solutionService.userFailedList(userProfile);
+        return DetailUserProfileResponse.from(userProfile, solvedProblemIds, failedProblemIds);
+    }
+
+    public UserProfile findByUser(User user){
+        return userProfileJpaRepository.findByUser(user).orElseThrow(()->
+                new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    public UserProfile findById(UUID profileId){
+        return userProfileJpaRepository.findById(profileId).orElseThrow(()->
+                new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## Description
유저 프로필 조회 기능 구현

## Changes

### user
- User
- UserController
- UserProfileService
- DetailUserProfileResponse

### problem
- Problem
- ProblemJpaRepository

### global
- UuidTypeBaseEntity
- LongTypeBaseEntity

## Additional context
- 회원가입 시 유저의 이메일 부분은 보류
- Problem의 PK를 Long으로 변경. 어짜피 Problem의 PK는 노출되어야 하기 때문.

Closes #23 