### PR TITLE
Feature/#55 카테고리 목록 조회, SolvedStatus 도메인 추가

### DIFF
--- a/src/main/java/com/example/comento/auth/config/AuthenticationConfig.java
+++ b/src/main/java/com/example/comento/auth/config/AuthenticationConfig.java
@@ -19,7 +19,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
 
     private static final String[] EXCLUDE_PATH_PATTERNS = {
             "/auth/sign-up", "/auth/login", "/users/ranking",
-            "/problems/algorithms", "/problems/collections",
+            "/problems/categories", "/problems/collections",
             "/solutions",
             "/swagger-ui/**", "/v3/api-docs/**"
     };

--- a/src/main/java/com/example/comento/category/controller/CategoryController.java
+++ b/src/main/java/com/example/comento/category/controller/CategoryController.java
@@ -1,8 +1,12 @@
 package com.example.comento.category.controller;
 
 import com.example.comento.category.domain.Category;
+import com.example.comento.category.dto.response.AllCategories;
 import com.example.comento.category.service.CategoryService;
+import com.example.comento.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,7 +14,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/problems/algorithms")
+@RequestMapping("/problems/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 
@@ -29,9 +33,10 @@ public class CategoryController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Category>> getAllCategories() {
-        List<Category> categories = categoryService.getAllCategories();
-        return ResponseEntity.ok(categories);
+    @Operation(summary = "모든 카테고리 목록 조회")
+    public ResponseEntity<ResponseDto<AllCategories>> getAllCategories() {
+        AllCategories categories = categoryService.getAllCategories();
+        return new ResponseEntity<>(ResponseDto.res(true, "카테고리 목록 조회 성공", categories), HttpStatus.OK);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/example/comento/category/dto/response/AllCategories.java
+++ b/src/main/java/com/example/comento/category/dto/response/AllCategories.java
@@ -1,0 +1,21 @@
+package com.example.comento.category.dto.response;
+
+
+import com.example.comento.category.domain.Category;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AllCategories {
+    List<CategoryResponse> categoryResponseList;
+
+    public static AllCategories from(List<Category> categories){
+        return new AllCategories(categories.stream()
+                .map(CategoryResponse::from)
+                .toList());
+    }
+}

--- a/src/main/java/com/example/comento/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/example/comento/category/dto/response/CategoryResponse.java
@@ -1,0 +1,19 @@
+package com.example.comento.category.dto.response;
+
+import com.example.comento.category.domain.Category;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CategoryResponse {
+    private UUID id;
+    private String name;
+
+    public static CategoryResponse from(Category category){
+        return new CategoryResponse(category.getId(), category.getName());
+    }
+}

--- a/src/main/java/com/example/comento/category/service/CategoryService.java
+++ b/src/main/java/com/example/comento/category/service/CategoryService.java
@@ -1,6 +1,7 @@
 package com.example.comento.category.service;
 
 import com.example.comento.category.domain.Category;
+import com.example.comento.category.dto.response.AllCategories;
 import com.example.comento.category.repository.CategoryJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,8 +31,8 @@ public class CategoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<Category> getAllCategories() {
-        return categoryRepository.findAll();
+    public AllCategories getAllCategories() {
+        return AllCategories.from(categoryRepository.findAll());
     }
 
     @Transactional

--- a/src/main/java/com/example/comento/problem/damain/Problem.java
+++ b/src/main/java/com/example/comento/problem/damain/Problem.java
@@ -4,6 +4,7 @@ import com.example.comento.global.domain.LongTypeBaseEntity;
 import com.example.comento.level.domain.Level;
 import com.example.comento.like.domain.ProblemLike;
 import com.example.comento.solution.domain.Solution;
+import com.example.comento.solvedstatus.domain.SolvedStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -66,5 +67,8 @@ public class Problem extends LongTypeBaseEntity {
 
     @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<TestCase> testCases;
+
+    @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<SolvedStatus> solvedStatuses;
 
 }

--- a/src/main/java/com/example/comento/solvedstatus/domain/SolvedStatus.java
+++ b/src/main/java/com/example/comento/solvedstatus/domain/SolvedStatus.java
@@ -1,0 +1,44 @@
+package com.example.comento.solvedstatus.domain;
+
+import com.example.comento.global.domain.UuidTypeBaseEntity;
+import com.example.comento.problem.damain.Problem;
+import com.example.comento.user.domain.UserProfile;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "solved_flag")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SolvedStatus extends UuidTypeBaseEntity {
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_profile_id", nullable = false)
+    private UserProfile userProfile;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    @Column(nullable = false)
+    private Boolean flag;
+
+    public SolvedStatus(UserProfile profile, Problem problem, Boolean flag){
+        this.userProfile = profile;
+        this.problem = problem;
+        this.flag = flag;
+    }
+
+    public void setTrue(){
+        this.flag = Boolean.TRUE;
+    }
+
+    public void setFalse(){
+        this.flag = Boolean.FALSE;
+    }
+
+}

--- a/src/main/java/com/example/comento/solvedstatus/repository/SolvedStatusRepository.java
+++ b/src/main/java/com/example/comento/solvedstatus/repository/SolvedStatusRepository.java
@@ -1,0 +1,11 @@
+package com.example.comento.solvedstatus.repository;
+
+import com.example.comento.solvedstatus.domain.SolvedStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface SolvedStatusRepository extends JpaRepository<SolvedStatus, UUID> {
+}

--- a/src/main/java/com/example/comento/solvedstatus/service/SolvedStatusService.java
+++ b/src/main/java/com/example/comento/solvedstatus/service/SolvedStatusService.java
@@ -1,0 +1,11 @@
+package com.example.comento.solvedstatus.service;
+
+import com.example.comento.solvedstatus.repository.SolvedStatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SolvedStatusService {
+    private final SolvedStatusRepository solvedStatusRepository;
+}

--- a/src/main/java/com/example/comento/user/domain/UserProfile.java
+++ b/src/main/java/com/example/comento/user/domain/UserProfile.java
@@ -3,6 +3,7 @@ package com.example.comento.user.domain;
 import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.like.domain.ProblemLike;
 import com.example.comento.solution.domain.Solution;
+import com.example.comento.solvedstatus.domain.SolvedStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -35,5 +36,8 @@ public class UserProfile extends UuidTypeBaseEntity {
 
     @OneToMany(mappedBy = "userProfile", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<ProblemLike> problemLikes;
+
+    @OneToMany(mappedBy = "userProfile", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<SolvedStatus> solvedStatuses;
 
 }


### PR DESCRIPTION
## Description
카테고리 목록 조회, SolvedStatus 도메인 추가

## Changes
### Category
- AllCategories
- CategoryResponse

### SolvedStatus
- SolvedStatus
- SolvedStatusRepository
- UserProfile
- Problem

## Additional context
- 카테고리 목록 조회는 기존 동작이 잘 이뤄지지 않아서 수정함
- uri의 경우도 기존 problems/algorithms에서 problems/categories로 변경. 보다 명확하게 명칭을 가져가기 위함.
- 문제를 풀었는지 여부를 확인하는 코드가 너무 많아짐. 따라서 SolvedStatus 도메인을 추가하고 내부에 flag 값을 설정하여 유저의 풀이여부를 빠르게 조회할 수 있도록 함

Closes #55