### PR TITLE
Feature/#59 문제 상세 조회 시 제출 수, 푼 유저 수, 정답률이 나오도록 추가

### DIFF
--- a/src/main/java/com/example/comento/problem/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/com/example/comento/problem/dto/response/ProblemDetailResponse.java
@@ -8,6 +8,7 @@ import com.example.comento.problem.damain.ProblemLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Getter
@@ -24,9 +25,18 @@ public class ProblemDetailResponse {
     private int timeLimit;
     private int memoryLimit;
     private String source;
+    private Long level;
     private List<String> problemCategoryList;
+    private Long numberOfProblemSolution;
+    private Long numberOfCorrectUser;
+    private Double roundedCorrectRate;
 
-    public static ProblemDetailResponse from(ProblemDetailInformation problemDetailInformation){
+
+
+    public static ProblemDetailResponse from(ProblemDetailInformation problemDetailInformation,
+                                             Long numberOfProblemSolution,
+                                             Long numberOfCorrectUser,
+                                             Double roundedCorrectRate){
         Problem problem = problemDetailInformation.getProblem();
         List<ProblemCategory> problemCategories = problem.getProblemCategoryList();
         return new ProblemDetailResponse(problemDetailInformation.getHasSolved(),
@@ -40,9 +50,13 @@ public class ProblemDetailResponse {
                 problem.getTimeLimit(),
                 problem.getMemoryLimit(),
                 problem.getSource(),
+                problem.getLevel().getId(),
                 problemCategories.stream()
                         .map(problemCategory->problemCategory.getCategory().getName())
-                        .toList());
+                        .toList(),
+                numberOfProblemSolution,
+                numberOfCorrectUser,
+                roundedCorrectRate);
     }
 
 }

--- a/src/main/java/com/example/comento/problem/dto/response/ProblemPreview.java
+++ b/src/main/java/com/example/comento/problem/dto/response/ProblemPreview.java
@@ -17,6 +17,7 @@ public class ProblemPreview {
     private Long problemId;
     private String title;
     private Boolean hasSolved;
+    private Long level;
     private List<String> categories;
 
     public static ProblemPreview from(ProblemDetailInformation problemDetailInformation){
@@ -25,6 +26,7 @@ public class ProblemPreview {
         return new ProblemPreview(problem.getId(),
                 problem.getTitle(),
                 problemDetailInformation.getHasSolved(),
+                problem.getLevel().getId(),
                 problemCategoryList.stream()
                         .map(problemCategory -> problemCategory.getCategory().getName())
                         .toList());

--- a/src/main/java/com/example/comento/problem/repository/problem/ProblemRepositoryImpl.java
+++ b/src/main/java/com/example/comento/problem/repository/problem/ProblemRepositoryImpl.java
@@ -61,15 +61,14 @@ public class ProblemRepositoryImpl implements ProblemCustomRepository{
         }
 
 
-
         if (isSolvedCondition != null && profileCondition != null) {
             if(isSolvedCondition){
                 predicate.and(solution.userProfile.eq(profileCondition)).and(solution.isCorrect.eq(isSolvedCondition));
             }
 
             if(!isSolvedCondition){
-                predicate.and(solvedStatus.userProfile.eq(profileCondition)).and(solvedStatus.flag.eq(false))
-                        .or(solvedStatus.flag.isNull());
+                predicate.and(solvedStatus.userProfile.eq(profileCondition).and(solvedStatus.flag.eq(false))
+                        .or(solvedStatus.flag.isNull()));
             }
         }
         if (collectionId != null) {

--- a/src/main/java/com/example/comento/solution/repository/SolutionJpaRepository.java
+++ b/src/main/java/com/example/comento/solution/repository/SolutionJpaRepository.java
@@ -16,6 +16,9 @@ import java.util.UUID;
 @Repository
 public interface SolutionJpaRepository extends JpaRepository<Solution, UUID> {
 
+    public Long countAllByProblem(Problem problem);
+
+
     @Query("select case when count(s)>1 then true else false end " +
             "from solution as s " +
             "where s.userProfile = :profile and s.problem = :problem ")

--- a/src/main/java/com/example/comento/solvedstatus/domain/SolvedStatus.java
+++ b/src/main/java/com/example/comento/solvedstatus/domain/SolvedStatus.java
@@ -11,7 +11,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity(name = "solved_flag")
+@Entity(name = "solved_status")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class SolvedStatus extends UuidTypeBaseEntity {

--- a/src/main/java/com/example/comento/solvedstatus/repository/SolvedStatusRepository.java
+++ b/src/main/java/com/example/comento/solvedstatus/repository/SolvedStatusRepository.java
@@ -13,4 +13,5 @@ import java.util.UUID;
 public interface SolvedStatusRepository extends JpaRepository<SolvedStatus, UUID> {
 
     public Optional<SolvedStatus> findSolvedStatusByProblemAndUserProfile(Problem problem, UserProfile profile);
+    public Long countAllByProblemAndFlag(Problem problem, Boolean flag);
 }


### PR DESCRIPTION
## Description
문제 상세 조회 시 제출 수, 푼 유저 수,  정답률이 나오도록 수정

## Changes
- ProblemDetailResponse
- ProblemPreview
- ProblemService
- SolutionJpaRepository
- SolvedStatusRepository

## Additional context
- 문제 목록 조회 시에도 문제의 레벨이 나오도록 수정 
- 정답률의 경우 푼 유저 수 / 문제의 풀이 수로 계산되며 소수점 3자리에서 반올림됨

Closes #59