### PR TITLE
Refactor/#61 문제 목록 조회 시 solvedStatus가 없는 문제가 출력되지 않던 것 수정

### DIFF
--- a/src/main/java/com/example/comento/auth/constant/TokenConstant.java
+++ b/src/main/java/com/example/comento/auth/constant/TokenConstant.java
@@ -5,5 +5,5 @@ import java.time.Duration;
 public class TokenConstant {
 
     public static final String ACCESS_TOKEN = "AccessToken";
-    public static final Duration ACCESS_TOKEN_MAX_AGE = Duration.ofMinutes(30);
+    public static final Duration ACCESS_TOKEN_MAX_AGE = Duration.ofDays(1);
 }

--- a/src/main/java/com/example/comento/problem/repository/problem/ProblemRepositoryImpl.java
+++ b/src/main/java/com/example/comento/problem/repository/problem/ProblemRepositoryImpl.java
@@ -67,8 +67,9 @@ public class ProblemRepositoryImpl implements ProblemCustomRepository{
             }
 
             if(!isSolvedCondition){
-                predicate.and(solvedStatus.userProfile.eq(profileCondition).and(solvedStatus.flag.eq(false))
-                        .or(solvedStatus.flag.isNull()));
+                //해당 유저의 solvedStatus=true 인 문제 제외. or로 problem 에 solvedStatus 자체가 없는 것도 포함.
+                predicate.and(solvedStatus.userProfile.eq(profileCondition).and(solvedStatus.flag.eq(true)).not()
+                        .or(solvedStatus.isNull()));
             }
         }
         if (collectionId != null) {
@@ -100,6 +101,7 @@ public class ProblemRepositoryImpl implements ProblemCustomRepository{
                 .leftJoin(problem.solvedStatuses, solvedStatus)
                 .where(predicate)
                 .groupBy(problem.id)
+                .orderBy(problem.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 //                .fetch();


### PR DESCRIPTION
## Description
문제 목록 조회 시 solvedStatus가 없는 문제가 출력되지 않던 것 수정

## Changes
- ProblemRepositoryImpl
- TokenConstant

## Additional context
- accessToken의 발급 시간도 30분에서 24시간으로 연장. 시간 상 refreshToken을 제외할 경우를 대비함.

Closes #61
