### PR TITLE
Feature/#52 채점 기능 구현

### DIFF
--- a/src/main/java/com/example/comento/collection/controller/CollectionController.java
+++ b/src/main/java/com/example/comento/collection/controller/CollectionController.java
@@ -22,7 +22,7 @@ public class CollectionController {
     @Operation(summary = "모든 문제집 목록 조회")
     public ResponseEntity<ResponseDto<AllCollections>> getAllCategories() {
         AllCollections allCollections = collectionService.getAllCollection();
-        return new ResponseEntity<>(ResponseDto.res(true, "카테고리 목록 조회 성공", allCollections), HttpStatus.OK);
+        return new ResponseEntity<>(ResponseDto.res(true, "문제집 목록 조회 성공", allCollections), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/comento/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/comento/global/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.example.comento.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/src/main/java/com/example/comento/global/exception/InternetException.java
+++ b/src/main/java/com/example/comento/global/exception/InternetException.java
@@ -1,0 +1,9 @@
+package com.example.comento.global.exception;
+
+import com.example.comento.global.exception.errorcode.ErrorCode;
+
+public class InternetException extends CustomException{
+    public InternetException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/comento/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/example/comento/global/exception/errorcode/ErrorCode.java
@@ -29,12 +29,14 @@ public enum ErrorCode {
     SOLUTION_NOT_FOUND("4043", "존재하지 않는 솔루션입니다"),
     LEVEL_NOT_FOUND("4044", "존재하지 않는 레벨입니다."),
     CATEGORY_NOT_FOUND("4044", "존재하지 않는 카테고리입니다."),
+    LANGUAGE_NOT_FOUND("4045", "존재하지 않는 언어입니다."),
 
     //Conflict
     LIKE_CONFLICT("4090", "불가한 좋아요 요청입니다."),
-    INVALID_AI_REVIEW("4091", "AI 리뷰 요청이 불가한 솔루션입니다.")
+    INVALID_AI_REVIEW("4091", "AI 리뷰 요청이 불가한 솔루션입니다."),
+    TEST_CASE_PARSE_ERROR("4092", "테스트 케이스 파싱 오류입니다."),
 
-
+    GRADING_SERVER_ERROR("5000", "채점 서버 응답에 실패했습니다.")
     ;
 
 

--- a/src/main/java/com/example/comento/like/repository/ProblemLikeJpaRepository.java
+++ b/src/main/java/com/example/comento/like/repository/ProblemLikeJpaRepository.java
@@ -13,4 +13,6 @@ import java.util.UUID;
 public interface ProblemLikeJpaRepository extends JpaRepository<ProblemLike, UUID> {
 
     Optional<ProblemLike> findByUserProfileAndProblem(UserProfile userProfile, Problem problem);
+
+    Boolean existsByProblemAndUserProfile(Problem problem, UserProfile userProfile);
 }

--- a/src/main/java/com/example/comento/problem/controller/ProblemController.java
+++ b/src/main/java/com/example/comento/problem/controller/ProblemController.java
@@ -8,6 +8,9 @@ import com.example.comento.problem.damain.Problem;
 import com.example.comento.problem.dto.response.ProblemPreviews;
 import com.example.comento.problem.dto.response.ProblemDetailResponse;
 import com.example.comento.problem.service.ProblemService;
+import com.example.comento.solution.dto.request.SolutionRequest;
+import com.example.comento.solution.dto.response.SolutionDetailResponse;
+import com.example.comento.solution.service.SolutionService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,6 +29,16 @@ public class ProblemController {
 
     private final ProblemLikeService problemLikeService;
     private final ProblemService problemService;
+    private final SolutionService solutionService;
+
+    @PostMapping("/{problem-id}")
+    @Operation(summary = "문제 풀이 제출 api")
+    public ResponseEntity<ResponseDto<SolutionDetailResponse>> solveProblem(@PathVariable("problem-id") Long problemId,
+                                                             @RequestBody SolutionRequest solutionRequest,
+                                                             @AuthenticationPrincipal Principal principal) {
+        SolutionDetailResponse solutionDetailResponse = solutionService.solveProblem(principal, problemId, solutionRequest);
+        return new ResponseEntity<>(ResponseDto.res(true, "풀이 제출 성공", solutionDetailResponse), HttpStatus.OK);
+    }
 
     @PutMapping("/{problem-id}")
     @Operation(summary = "문제 수정 api")

--- a/src/main/java/com/example/comento/problem/dto/request/TestCaseRequest.java
+++ b/src/main/java/com/example/comento/problem/dto/request/TestCaseRequest.java
@@ -1,0 +1,22 @@
+package com.example.comento.problem.dto.request;
+
+import com.example.comento.problem.damain.TestCase;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class TestCaseRequest {
+    @ToString.Include
+    private String stdin;
+    @ToString.Include
+    @JsonProperty("expected_output")
+    private String expected_output;
+
+    public static TestCaseRequest from(TestCase testCase){
+        return new TestCaseRequest(testCase.getInput(), testCase.getOutput());
+    }
+}

--- a/src/main/java/com/example/comento/problem/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/com/example/comento/problem/dto/response/ProblemDetailResponse.java
@@ -15,6 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 public class ProblemDetailResponse {
     private Boolean hasSolved;
+    private Boolean hasLiked;
     private Long id;
     private String title;
     private String content;
@@ -34,12 +35,14 @@ public class ProblemDetailResponse {
 
 
     public static ProblemDetailResponse from(ProblemDetailInformation problemDetailInformation,
+                                             Boolean hasLiked,
                                              Long numberOfProblemSolution,
                                              Long numberOfCorrectUser,
                                              Double roundedCorrectRate){
         Problem problem = problemDetailInformation.getProblem();
         List<ProblemCategory> problemCategories = problem.getProblemCategoryList();
         return new ProblemDetailResponse(problemDetailInformation.getHasSolved(),
+                hasLiked,
                 problem.getId(),
                 problem.getTitle(),
                 problem.getContent(),

--- a/src/main/java/com/example/comento/problem/service/ProblemService.java
+++ b/src/main/java/com/example/comento/problem/service/ProblemService.java
@@ -20,7 +20,6 @@ import com.example.comento.problem.repository.ProblemCategoryJpaRepository;
 import com.example.comento.problem.repository.TestCaseJpaRepository;
 import com.example.comento.problem.repository.problem.ProblemRepository;
 import com.example.comento.solution.repository.SolutionJpaRepository;
-import com.example.comento.solvedstatus.domain.SolvedStatus;
 import com.example.comento.solvedstatus.repository.SolvedStatusRepository;
 import com.example.comento.user.domain.UserProfile;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/comento/problem/service/ProblemService.java
+++ b/src/main/java/com/example/comento/problem/service/ProblemService.java
@@ -8,6 +8,7 @@ import com.example.comento.global.exception.errorcode.ErrorCode;
 import com.example.comento.level.domain.Level;
 import com.example.comento.level.repository.LevelJpaRepository;
 import com.example.comento.level.service.LevelService;
+import com.example.comento.like.repository.ProblemLikeJpaRepository;
 import com.example.comento.problem.damain.Problem;
 import com.example.comento.problem.damain.ProblemCategory;
 import com.example.comento.problem.damain.TestCase;
@@ -49,6 +50,7 @@ public class ProblemService {
     private final SolvedStatusRepository solvedStatusRepository;
     private final ProblemCategoryJpaRepository problemCategoryJpaRepository;
     private final TestCaseJpaRepository testCaseJpaRepository;
+    private final ProblemLikeJpaRepository problemLikeJpaRepository;
 
     public  ProblemPreviews getProblems(int size,
                                        int page,
@@ -99,9 +101,11 @@ public class ProblemService {
         Problem problem = findById(problemId);
         UserProfile userProfile = principal.getProfile();
         ProblemDetailInformation problemDetailInformation =  new ProblemDetailInformation(problem, false);
-        
+        Boolean hasLiked = false;
+
         if(userProfile != null){
             Boolean hasSolved = solutionJpaRepository.isUserSolved(userProfile, problem);
+            hasLiked = problemLikeJpaRepository.existsByProblemAndUserProfile(problem, userProfile);
             problemDetailInformation = new ProblemDetailInformation(problem, hasSolved);
         }
 
@@ -113,6 +117,7 @@ public class ProblemService {
         BigDecimal roundedCorrectRate = new BigDecimal(correctRate).setScale(3, RoundingMode.HALF_UP);
 
         return ProblemDetailResponse.from(problemDetailInformation,
+                hasLiked,
                 numberOfProblemSolution,
                 numberOfCorrect,
                 roundedCorrectRate.doubleValue());

--- a/src/main/java/com/example/comento/solution/domain/Language.java
+++ b/src/main/java/com/example/comento/solution/domain/Language.java
@@ -1,0 +1,33 @@
+package com.example.comento.solution.domain;
+
+import com.example.comento.global.exception.NotFoundException;
+import com.example.comento.global.exception.errorcode.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum Language {
+    C("c", 50),
+    C_PLUS_PLUS("c++", 54),
+    C_SHARP("c#", 51),
+    JAVA("java", 62),
+    PYTHON("python", 71),
+    KOTLIN("kotlin", 78),
+    JAVA_SCRIPT("javascript", 63),
+    R("r", 80),
+    GO("go", 60),
+    PHP("php", 68);
+
+    private final String name;
+    private final int id;
+
+    public static Language find(String name){
+         return Arrays.stream(Language.values())
+                .filter(language -> name.equals(language.getName()))
+                .findFirst()
+                .orElseThrow(()->new NotFoundException(ErrorCode.LANGUAGE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/comento/solution/domain/Solution.java
+++ b/src/main/java/com/example/comento/solution/domain/Solution.java
@@ -4,16 +4,13 @@ import com.example.comento.global.domain.UuidTypeBaseEntity;
 import com.example.comento.problem.damain.Problem;
 import com.example.comento.user.domain.UserProfile;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.engine.internal.Cascade;
+import lombok.*;
 
 @Entity(name = "solution")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@Builder
 public class Solution extends UuidTypeBaseEntity {
 
     @Column(nullable = false)
@@ -29,7 +26,10 @@ public class Solution extends UuidTypeBaseEntity {
     private int memory;
 
     @Column(nullable = false)
-    private int time;
+    private String time;
+
+    @Column(nullable = true)
+    private String errorReason;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
 //    @JoinColumn(name = "user_profile_id", nullable = false)

--- a/src/main/java/com/example/comento/solution/dto/request/GradingServerRequest.java
+++ b/src/main/java/com/example/comento/solution/dto/request/GradingServerRequest.java
@@ -1,0 +1,30 @@
+package com.example.comento.solution.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@AllArgsConstructor
+@Getter
+@ToString
+@NoArgsConstructor
+@Builder
+public class GradingServerRequest {
+    @JsonProperty("source_code")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String source_code;
+
+    @JsonProperty("language_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer language_id;
+
+    @JsonProperty("test_case")
+    private String test_case;
+
+    @JsonProperty("cpu_time_limit")
+    private String cpu_time_limit;
+
+    @JsonProperty("memory_limit")
+    private String memory_limit;
+
+}

--- a/src/main/java/com/example/comento/solution/dto/request/SolutionRequest.java
+++ b/src/main/java/com/example/comento/solution/dto/request/SolutionRequest.java
@@ -1,0 +1,14 @@
+package com.example.comento.solution.dto.request;
+
+import io.micrometer.common.lang.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+public class SolutionRequest {
+    @NotBlank(message = "언어는 선택은 필수입니다.")
+    private String language;
+    @Length(max = 2000, message = "제출 가능 코드 길이는 2000자입니다.")
+    private String code;
+}

--- a/src/main/java/com/example/comento/solution/dto/response/GradingServerResponse.java
+++ b/src/main/java/com/example/comento/solution/dto/response/GradingServerResponse.java
@@ -1,0 +1,33 @@
+package com.example.comento.solution.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+public class GradingServerResponse {
+    @JsonProperty("all_success")
+    private boolean allSuccess;
+    @JsonProperty("max_memory")
+    private int maxMemory;
+    @JsonProperty("max_time")
+    private String maxTime;
+    @JsonProperty("results")
+    private List<Result> results;
+
+    @Data
+    public static class Result {
+        private String token;
+        private String status;
+        private String time;
+        private int memory;
+    }
+}
+

--- a/src/main/java/com/example/comento/solution/dto/response/SolutionDetailResponse.java
+++ b/src/main/java/com/example/comento/solution/dto/response/SolutionDetailResponse.java
@@ -20,7 +20,8 @@ public class SolutionDetailResponse {
     private String aiFeedback;
 
     private String language;
-    private int time;
+    private String errorReason;
+    private String time;
     private int memory;
     private boolean isCorrect;
     private String timeAgo;
@@ -34,6 +35,7 @@ public class SolutionDetailResponse {
                 solution.getCode(),
                 solution.getAiFeedback() != null ? solution.getAiFeedback().getContent() : null,
                 solution.getLanguage(),
+                solution.getErrorReason(),
                 solution.getTime(),
                 solution.getMemory(),
                 solution.isCorrect(),

--- a/src/main/java/com/example/comento/solvedstatus/repository/SolvedStatusRepository.java
+++ b/src/main/java/com/example/comento/solvedstatus/repository/SolvedStatusRepository.java
@@ -2,16 +2,22 @@ package com.example.comento.solvedstatus.repository;
 
 import com.example.comento.problem.damain.Problem;
 import com.example.comento.solvedstatus.domain.SolvedStatus;
+import com.example.comento.user.domain.User;
 import com.example.comento.user.domain.UserProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface SolvedStatusRepository extends JpaRepository<SolvedStatus, UUID> {
 
-    public Optional<SolvedStatus> findSolvedStatusByProblemAndUserProfile(Problem problem, UserProfile profile);
+    public Optional<SolvedStatus> findByUserProfileAndProblem(UserProfile profile, Problem problem);
+    public Boolean existsByUserProfileAndProblem(UserProfile profile, Problem problem);
     public Long countAllByProblemAndFlag(Problem problem, Boolean flag);
+
+    public List<SolvedStatus> findAllByUserProfileAndFlagIsTrue(UserProfile userProfile);
+    public List<SolvedStatus> findAllByUserProfileAndFlagIsFalse(UserProfile userProfile);
 }

--- a/src/main/java/com/example/comento/solvedstatus/service/SolvedStatusService.java
+++ b/src/main/java/com/example/comento/solvedstatus/service/SolvedStatusService.java
@@ -1,11 +1,34 @@
 package com.example.comento.solvedstatus.service;
 
+import com.example.comento.problem.damain.Problem;
+import com.example.comento.solvedstatus.domain.SolvedStatus;
 import com.example.comento.solvedstatus.repository.SolvedStatusRepository;
+import com.example.comento.user.domain.UserProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class SolvedStatusService {
     private final SolvedStatusRepository solvedStatusRepository;
+
+    public void registerSolvedStatus(UserProfile profile, Problem problem, Boolean isSolved){
+        if(solvedStatusRepository.existsByUserProfileAndProblem(profile, problem)) {
+            SolvedStatus solvedStatus = find(profile, problem);
+            //기존 false였고 이번에 맞았다면 True로 설정.
+            if (!solvedStatus.getFlag() && isSolved) {
+                solvedStatus.setTrue();
+                solvedStatusRepository.save(solvedStatus);
+            }
+        }else {
+            SolvedStatus solvedStatus = new SolvedStatus(profile, problem, isSolved);
+            solvedStatusRepository.save(solvedStatus);
+        }
+    }
+
+    public SolvedStatus find(UserProfile profile, Problem problem){
+        return solvedStatusRepository.findByUserProfileAndProblem(profile, problem).orElseGet(null);
+    }
 }

--- a/src/main/java/com/example/comento/user/domain/UserProfile.java
+++ b/src/main/java/com/example/comento/user/domain/UserProfile.java
@@ -40,4 +40,8 @@ public class UserProfile extends UuidTypeBaseEntity {
     @OneToMany(mappedBy = "userProfile", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<SolvedStatus> solvedStatuses;
 
+    public void increaseExperience(Long experience){
+        this.experience += experience;
+    }
+
 }

--- a/src/main/java/com/example/comento/user/service/UserProfileService.java
+++ b/src/main/java/com/example/comento/user/service/UserProfileService.java
@@ -2,6 +2,7 @@ package com.example.comento.user.service;
 
 import com.example.comento.global.exception.NotFoundException;
 import com.example.comento.global.exception.errorcode.ErrorCode;
+import com.example.comento.problem.repository.problem.ProblemRepository;
 import com.example.comento.solution.dao.ProblemId;
 import com.example.comento.solution.dto.response.ProblemIdsResponse;
 import com.example.comento.solution.service.SolutionService;
@@ -20,15 +21,15 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class UserProfileService {
 
-    private final SolutionService solutionService;
     private final UserProfileJpaRepository userProfileJpaRepository;
+    private final ProblemRepository problemRepository;
 
     public DetailUserProfileResponse getDetailProfile(UUID userProfileId){
         UserProfile userProfile = findById(userProfileId);
 
-        ProblemIdsResponse solvedProblemIds = solutionService.userSolvedList(userProfile);
-        ProblemIdsResponse failedProblemIds = solutionService.userFailedList(userProfile);
-        ProblemIdsResponse likedProblemIds = solutionService.userLikedList(userProfile);
+        ProblemIdsResponse solvedProblemIds = userSolvedList(userProfile);
+        ProblemIdsResponse failedProblemIds = userFailedList(userProfile);
+        ProblemIdsResponse likedProblemIds = userLikedList(userProfile);
 
         return DetailUserProfileResponse.from(userProfile, solvedProblemIds, failedProblemIds, likedProblemIds);
     }
@@ -46,5 +47,20 @@ public class UserProfileService {
     public UserProfile findById(UUID profileId){
         return userProfileJpaRepository.findById(profileId).orElseThrow(()->
                 new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private ProblemIdsResponse userLikedList(UserProfile userprofile) {
+        List<ProblemId> problemIdList = problemRepository.getLikedProblemList(userprofile);
+        return ProblemIdsResponse.from(problemIdList);
+    }
+
+    public ProblemIdsResponse userSolvedList(UserProfile userProfile) {
+        List<ProblemId> problemIdList = problemRepository.getSolvedProblemList(userProfile);
+        return ProblemIdsResponse.from(problemIdList);
+    }
+
+    public ProblemIdsResponse userFailedList(UserProfile userProfile) {
+        List<ProblemId> problemIdList = problemRepository.getFailedProblemList(userProfile);
+        return ProblemIdsResponse.from(problemIdList);
     }
 }


### PR DESCRIPTION
## Description
채점 기능 구현

## Changes
### Global
- 채점 서버 연결
- WebClientConfig

### Problem
- ProblemController
- Language

### Solution
- SolutionService
- SolutionRequest
- GradingServerRequest
- GradingServerResponse
- SolutionDetailResponse
- SolveStateService

## Additional context
- 대략적인 구조는 다음과 같음. 클라이언트 -> 백엔드 서버 -> 채점 서버 -> 백엔드서버 -> 클라이언트. 백엔드 서버에서 채점서버로의 응답은 WebClient를 사용했으나 동기적으로 동작함. (Block됨)
- 지원하는 언어의 경우 아래와 같음. 프론트에서 보낼 때 언어명을 lower하게 보내줘야 함.
  - c
  - c#
  - c++
  - java
  - python
  - kotlin
  - javascript
  - r
  - go
  - php

Closes #52 