### PR TITLE
Refactor/#78 소셜 로그인 수정

### DIFF
--- a/src/main/java/com/example/comento/admin/AdminController.java
+++ b/src/main/java/com/example/comento/admin/AdminController.java
@@ -1,5 +1,6 @@
 package com.example.comento.admin;
 
+import com.example.comento.admin.annotation.ExistCategories;
 import com.example.comento.global.dto.ResponseDto;
 import com.example.comento.problem.damain.Problem;
 import com.example.comento.problem.dto.request.ProblemRegisterRequest;
@@ -21,7 +22,7 @@ public class AdminController {
 
     @PostMapping("/problems")
     @Operation(summary = "문제 등록 api")
-    public ResponseEntity<ResponseDto<Void>> createProblem(@RequestBody ProblemRegisterRequest problemRegisterRequest) {
+    public ResponseEntity<ResponseDto<Void>> createProblem(@RequestBody @ExistCategories  ProblemRegisterRequest problemRegisterRequest) {
         problemService.createProblem(problemRegisterRequest);
         return new ResponseEntity<>(ResponseDto.res(true, "문제 작성 성공"), HttpStatus.CREATED);
     }

--- a/src/main/java/com/example/comento/admin/annotation/ExistCategories.java
+++ b/src/main/java/com/example/comento/admin/annotation/ExistCategories.java
@@ -1,0 +1,17 @@
+package com.example.comento.admin.annotation;
+
+import com.example.comento.admin.vaildator.CategoriesExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CategoriesExistValidator.class)
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistCategories {
+    String message() default "해당 카테고리가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/comento/admin/vaildator/CategoriesExistValidator.java
+++ b/src/main/java/com/example/comento/admin/vaildator/CategoriesExistValidator.java
@@ -1,0 +1,32 @@
+package com.example.comento.admin.vaildator;
+
+import com.example.comento.admin.annotation.ExistCategories;
+import com.example.comento.category.service.CategoryService;
+import com.example.comento.problem.dto.request.ProblemRegisterRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CategoriesExistValidator implements ConstraintValidator<ExistCategories, ProblemRegisterRequest> {
+    private final CategoryService categoryService;
+
+    @Override
+    public void initialize(ExistCategories constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(ProblemRegisterRequest problemRegisterRequest, ConstraintValidatorContext constraintValidatorContext) {
+        List<String> categoryNames = problemRegisterRequest.getCategoryNames();
+        categoryService.isExistCategory(categoryNames);
+        return true;
+    }
+
+}

--- a/src/main/java/com/example/comento/auth/controller/AuthController.java
+++ b/src/main/java/com/example/comento/auth/controller/AuthController.java
@@ -8,26 +8,45 @@ import com.example.comento.auth.dto.response.TokenResponseCookies;
 import com.example.comento.auth.service.AuthService;
 import com.example.comento.auth.service.TokenService;
 import com.example.comento.global.dto.ResponseDto;
+import com.example.comento.global.util.CookieUtil;
 import com.example.comento.user.domain.User;
+import com.example.comento.user.domain.UserProfile;
 import com.example.comento.user.dto.response.UserProfileResponse;
 import com.example.comento.user.service.UserProfileService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.UUID;
+
+import static com.example.comento.auth.constant.TokenConstant.ACCESS_TOKEN_MAX_AGE;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
+@Slf4j
 public class AuthController {
     private final AuthService authService;
     private final TokenService tokenService;
     private final UserProfileService userProfileService;
+
+    private final String userprofileIdCookieName = "userProfileId";
+
+    @Value("${domain.uri}")
+    private String domainUri;
+    @Value("${domain}")
+    private String domain;
 
     @PostMapping("/sign-up")
     @Operation(summary = "회원가입 api", description = "userId, password, name을 입력하여 회원가입")
@@ -52,6 +71,7 @@ public class AuthController {
     public ResponseEntity<ResponseDto<Void>> logout(@AuthenticationPrincipal Principal principal, HttpServletResponse response){
         TokenResponseCookies cookies = tokenService.issueExpiredToken();
         response.addHeader("set-cookie", cookies.getAccessToken().toString());
+        response.addHeader("set-cookie", CookieUtil.createCookie(userprofileIdCookieName, null, Duration.ZERO, domain, false).toString());
         return new ResponseEntity<>(ResponseDto.res(true, "로그아웃 성공"), HttpStatus.OK);
     }
 
@@ -60,11 +80,21 @@ public class AuthController {
     public ResponseEntity<ResponseDto<UserProfileResponse>> naverSignUp(
             @RequestParam(name = "code") String authorizeCode,
             @RequestParam(name = "state") String state,
-            HttpServletResponse response){
+            HttpServletResponse response) throws IOException {
+
         User user = authService.naverOAuthLogin(authorizeCode, state);
         UUID id = user.getId();
+
         TokenResponseCookies cookies = tokenService.issueToken(id.toString());
         response.addHeader("set-cookie", cookies.getAccessToken().toString());
+
+        UserProfile userProfile = userProfileService.findByUser(user);
+
+        ResponseCookie profileIdCookie = CookieUtil.createCookie(userprofileIdCookieName, userProfile.getId().toString(), ACCESS_TOKEN_MAX_AGE, domain, false);
+        response.addHeader("set-cookie", profileIdCookie.toString());
+
+        response.sendRedirect(domainUri);
+
         UserProfileResponse userProfileResponse = userProfileService.getProfileResponse(user);
         return new ResponseEntity<>(ResponseDto.res(true, "Naver 로그인 성공", userProfileResponse), HttpStatus.OK);
     }

--- a/src/main/java/com/example/comento/auth/service/AuthService.java
+++ b/src/main/java/com/example/comento/auth/service/AuthService.java
@@ -81,8 +81,6 @@ public class AuthService {
     public User naverOAuthLogin(String authorizeCode, String state){
 
         NaverOAuthTokenResponse naverOAuthTokenResponse = getNaverAccessToken(authorizeCode, state);
-        log.info(naverOAuthTokenResponse.toString());
-        log.info(naverOAuthTokenResponse.getAccessToken());
         NaverUserProfile naverUserProfile = getNaverUserProfile(naverOAuthTokenResponse.getAccessToken());
         NaverUserResponse userResponse = naverUserProfile.getResponse();
 

--- a/src/main/java/com/example/comento/auth/service/TokenService.java
+++ b/src/main/java/com/example/comento/auth/service/TokenService.java
@@ -23,6 +23,11 @@ public class TokenService {
         return new TokenResponseCookies(accessTokenCookie);
     }
 
+    public TokenResponseCookies issueToken(String payload, String domain){
+        ResponseCookie accessTokenCookie = createAccessTokenCookie(payload, domain);
+        return new TokenResponseCookies(accessTokenCookie);
+    }
+
     public TokenResponseCookies issueExpiredToken(){
         ResponseCookie expiredTokenCookie = createExpiredAccessTokenCookies();
         return new TokenResponseCookies(expiredTokenCookie);
@@ -32,6 +37,12 @@ public class TokenService {
         String accessToken = accessTokenProvider.createToken(payload);
         String bearerToken = JwtEncoder.encodeJwtToken(accessToken);
         return  CookieUtil.createTokenCookie(ACCESS_TOKEN, bearerToken, ACCESS_TOKEN_MAX_AGE);
+    }
+
+    private ResponseCookie createAccessTokenCookie(String payload, String domain){
+        String accessToken = accessTokenProvider.createToken(payload);
+        String bearerToken = JwtEncoder.encodeJwtToken(accessToken);
+        return CookieUtil.createTokenCookie(ACCESS_TOKEN, bearerToken, ACCESS_TOKEN_MAX_AGE, domain);
     }
 
     private ResponseCookie createExpiredAccessTokenCookies(){

--- a/src/main/java/com/example/comento/category/repository/CategoryJpaRepository.java
+++ b/src/main/java/com/example/comento/category/repository/CategoryJpaRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 @Repository
 public interface CategoryJpaRepository extends JpaRepository<Category, UUID> {
     public Optional<Category> findCategoryByName(String name);
+
+    public boolean existsByName(String name);
 }

--- a/src/main/java/com/example/comento/category/service/CategoryService.java
+++ b/src/main/java/com/example/comento/category/service/CategoryService.java
@@ -54,4 +54,11 @@ public class CategoryService {
         return categoryRepository.findCategoryByName(name).orElseThrow(()->
                 new NotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
     }
+
+    public boolean isExistCategory(List<String> names){
+        if(names.stream().anyMatch(name -> !categoryRepository.existsByName(name))){
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/example/comento/global/util/CookieUtil.java
+++ b/src/main/java/com/example/comento/global/util/CookieUtil.java
@@ -4,6 +4,7 @@ import com.example.comento.global.exception.UnauthorizedException;
 import com.example.comento.global.exception.errorcode.ErrorCode;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 
 import java.time.Duration;
@@ -18,6 +19,30 @@ public class CookieUtil {
                 .httpOnly(true)
                 .sameSite("None")
                 .secure(true)
+                .build();
+    }
+
+    public static ResponseCookie createTokenCookie(
+            String tokenName, String tokenValue, Duration maxAge, String domain){
+        return ResponseCookie.from(tokenName, tokenValue)
+                .maxAge(maxAge)
+                .path("/")
+                .httpOnly(true)
+                .sameSite("None")
+                .secure(true)
+                .domain(domain)
+                .build();
+    }
+
+    public static ResponseCookie createCookie(
+            String tokenName, String tokenValue, Duration maxAge, String domain, boolean httpOnly){
+        return ResponseCookie.from(tokenName, tokenValue)
+                .maxAge(maxAge)
+                .path("/")
+                .httpOnly(httpOnly)
+                .sameSite("None")
+                .secure(true)
+                .domain(domain)
                 .build();
     }
 

--- a/src/main/java/com/example/comento/problem/service/ProblemService.java
+++ b/src/main/java/com/example/comento/problem/service/ProblemService.java
@@ -72,6 +72,11 @@ public class ProblemService {
                 new NotFoundException(ErrorCode.PROBLEM_NOT_FOUND));
     }
 
+    /**
+     * admin 기능으로 문제 등록을 편하게 하기 위해서 만든 메서드임.
+     * @ExistCategories로 카테고리 인증을 먼저 진행되므로 중간에 문제 등록 성공 이후 실패하는 케이스를 만들지 않도록 함.
+     * @param problemRegisterRequest 문제 등록 시 필요한 request 를 받아오는 dto.
+     */
     @Transactional
     public void createProblem(ProblemRegisterRequest problemRegisterRequest) {
         Problem problem = registerProblem(problemRegisterRequest);

--- a/src/main/java/com/example/comento/solution/domain/AiFeedback.java
+++ b/src/main/java/com/example/comento/solution/domain/AiFeedback.java
@@ -11,7 +11,7 @@ import lombok.*;
 @Builder
 public class AiFeedback extends UuidTypeBaseEntity {
 
-    @Column(length=2000)
+    @Column(length=5000)
     private String content;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/comento/solution/templates/LlmApiTemplate.java
+++ b/src/main/java/com/example/comento/solution/templates/LlmApiTemplate.java
@@ -29,6 +29,7 @@ public class LlmApiTemplate {
             출력값 예시: {outputExample}
             카테고리: {category}
             코드가 아닌 다른 입력이 들어온 경우 무시합니다.
+            답변을 길고 자세히 작성해줘
             """;
     public static final String USER_CODE = """
             isCorrect: %s,


### PR DESCRIPTION
## Description
소셜 로그인 수정

## Changes

### Admin
- AdminController
- ExistCategories
- CategoriesExistValidator

### Auth
- AuthController
- AuthService

### Global
- CookieUtil

## Additional context
- 현재 구조는 프론트에서 소셜 로그인 창을 띄워주면 리다이렉트를 서버로 하여 서버에서 바로 진행하는 방법임. 즉, authorize code도 서버에서 받는 구조인데 이 방법을 사용하게 되면서 response를 하면 서버쪽으로 페이지 전환이 되어버림.
- 따라서 해당 서버는 RestFul을 지양함에도 강제적으로 소셜 로그인 시 리다이렉트를 하고 토큰과 UserProfileId를 쿠키로 클라이언트에게 전달함
- 기존에 카테고리가 존재하지 않는 상태로 등록하려하면 카테고리 검증로직이 Problem 객체 생성 이후에 존재했어서 DB에서 pk num이 increase되어버리고 문제는 생성되지 않는 문제가 존재했음. 이를 커스텀 어노테이션으로 사전에 검증하여 방지하도록 수정

Closes #78 